### PR TITLE
python 3.10 compatible

### DIFF
--- a/web-interface/bottle.py
+++ b/web-interface/bottle.py
@@ -129,7 +129,11 @@ if py3k:
     from urllib.parse import urlencode, quote as urlquote, unquote as urlunquote
     urlunquote = functools.partial(urlunquote, encoding='latin1')
     from http.cookies import SimpleCookie, Morsel, CookieError
-    from collections import MutableMapping as DictMixin
+    try:
+        from collections import MutableMapping as DictMixin
+    except ImportError:
+        from collections.abc import MutableMapping as DictMixin
+        
     import pickle
     from io import BytesIO
     import configparser


### PR DESCRIPTION
`MutableMapping`  in `collections` depreciated and moved to `collections.abc` in python 3.10